### PR TITLE
Add tabbed report layout with summary callouts

### DIFF
--- a/ui/assets/styles.css
+++ b/ui/assets/styles.css
@@ -169,6 +169,44 @@ body {
   align-self: flex-start;
 }
 
+.tab-bar {
+  display: inline-flex;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 6px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  margin-top: 4px;
+}
+
+.tab-button {
+  background: transparent;
+  border: 1px solid transparent;
+  color: #cbd5e1;
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tab-button.active {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+
+.tab-panel[hidden] {
+  display: none;
+}
+
+.tab-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 .panel {
   background: var(--panel);
   border-radius: 18px;
@@ -222,6 +260,12 @@ h2 {
 .summary-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.admin-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 12px;
 }
 
@@ -307,10 +351,70 @@ h2 {
   background: var(--low);
 }
 
+.tone-identity {
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
 .category-grid {
   display: grid;
   gap: 12px;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.callout-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+
+.callout-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.callout-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.callout-list {
+  display: grid;
+  gap: 8px;
+}
+
+.callout-item {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.callout-item:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.callout-item strong {
+  display: block;
+  color: #fff;
+  margin-bottom: 4px;
+}
+
+.callout-item .meta-row {
+  font-size: 12px;
+  color: #94a3b8;
 }
 
 .category-card {

--- a/ui/index.html
+++ b/ui/index.html
@@ -50,87 +50,173 @@
         </div>
       </section>
 
-      <section class="panel">
-        <div class="section-heading">
-          <div>
-            <p class="eyebrow">Overall health</p>
-            <h2>Severity distribution & metrics</h2>
-            <p class="muted">Track critical and high-risk items, privileged account counts, and audit freshness.</p>
+      <div class="tab-bar" role="tablist" aria-label="Report navigation">
+        <button class="tab-button active" data-tab="summary" role="tab" aria-selected="true">Summary</button>
+        <button class="tab-button" data-tab="categories" role="tab" aria-selected="false">Categories</button>
+        <button class="tab-button" data-tab="findings" role="tab" aria-selected="false">Findings</button>
+      </div>
+
+      <section class="tab-panel" data-tab-panel="summary" role="tabpanel">
+        <section class="panel">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">Identity administrators</p>
+              <h2>Domain Admins, Enterprise Admins, Schema Admins</h2>
+              <p class="muted">Monitor privileged groups to understand who can make forest-wide or schema changes.</p>
+            </div>
           </div>
-          <div class="meta-stats" id="meta-stats"></div>
-        </div>
-        <div class="summary-grid">
-          <article class="summary-card tone-critical">
-            <div class="card-top">
-              <div>
-                <p class="label">Critical</p>
-                <p class="count" id="critical-count">0</p>
+          <div class="admin-grid" id="admin-grid">
+            <article class="summary-card tone-identity">
+              <div class="card-top">
+                <div>
+                  <p class="label">Domain Admins</p>
+                  <p class="count" id="domain-admins-count">—</p>
+                </div>
+                <span class="icon">🛡️</span>
               </div>
-              <span class="icon">⚠️</span>
-            </div>
-            <p class="helper">Issues that need immediate attention.</p>
-            <div class="progress"><span id="critical-progress"></span></div>
-          </article>
-          <article class="summary-card tone-high">
-            <div class="card-top">
-              <div>
-                <p class="label">High</p>
-                <p class="count" id="high-count">0</p>
+              <p class="helper">Accounts that control the domain scope.</p>
+            </article>
+            <article class="summary-card tone-identity">
+              <div class="card-top">
+                <div>
+                  <p class="label">Enterprise Admins</p>
+                  <p class="count" id="enterprise-admins-count">—</p>
+                </div>
+                <span class="icon">🏢</span>
               </div>
-              <span class="icon">🚨</span>
-            </div>
-            <p class="helper">Elevated risk requiring near-term remediation.</p>
-            <div class="progress"><span id="high-progress"></span></div>
-          </article>
-          <article class="summary-card tone-medium">
-            <div class="card-top">
-              <div>
-                <p class="label">Medium</p>
-                <p class="count" id="medium-count">0</p>
+              <p class="helper">Forest-wide administrative identities.</p>
+            </article>
+            <article class="summary-card tone-identity">
+              <div class="card-top">
+                <div>
+                  <p class="label">Schema Admins</p>
+                  <p class="count" id="schema-admins-count">—</p>
+                </div>
+                <span class="icon">📐</span>
               </div>
-              <span class="icon">📋</span>
+              <p class="helper">Principals that can alter the AD schema.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="panel">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">Overall health</p>
+              <h2>Severity distribution & metrics</h2>
+              <p class="muted">Track critical and high-risk items, privileged account counts, and audit freshness.</p>
             </div>
-            <p class="helper">Configuration gaps to plan into backlog.</p>
-            <div class="progress"><span id="medium-progress"></span></div>
-          </article>
-          <article class="summary-card tone-low">
-            <div class="card-top">
-              <div>
-                <p class="label">Low</p>
-                <p class="count" id="low-count">0</p>
+            <div class="meta-stats" id="meta-stats"></div>
+          </div>
+          <div class="summary-grid">
+            <article class="summary-card tone-critical">
+              <div class="card-top">
+                <div>
+                  <p class="label">Critical</p>
+                  <p class="count" id="critical-count">0</p>
+                </div>
+                <span class="icon">⚠️</span>
               </div>
-              <span class="icon">ℹ️</span>
+              <p class="helper">Issues that need immediate attention.</p>
+              <div class="progress"><span id="critical-progress"></span></div>
+            </article>
+            <article class="summary-card tone-high">
+              <div class="card-top">
+                <div>
+                  <p class="label">High</p>
+                  <p class="count" id="high-count">0</p>
+                </div>
+                <span class="icon">🚨</span>
+              </div>
+              <p class="helper">Elevated risk requiring near-term remediation.</p>
+              <div class="progress"><span id="high-progress"></span></div>
+            </article>
+            <article class="summary-card tone-medium">
+              <div class="card-top">
+                <div>
+                  <p class="label">Medium</p>
+                  <p class="count" id="medium-count">0</p>
+                </div>
+                <span class="icon">📋</span>
+              </div>
+              <p class="helper">Configuration gaps to plan into backlog.</p>
+              <div class="progress"><span id="medium-progress"></span></div>
+            </article>
+            <article class="summary-card tone-low">
+              <div class="card-top">
+                <div>
+                  <p class="label">Low</p>
+                  <p class="count" id="low-count">0</p>
+                </div>
+                <span class="icon">ℹ️</span>
+              </div>
+              <p class="helper">Informational items for visibility.</p>
+              <div class="progress"><span id="low-progress"></span></div>
+            </article>
+          </div>
+          <div class="meta-row-bar">
+            <span id="total-count" class="pill">0 findings</span>
+            <span id="last-updated" class="pill">Waiting for data…</span>
+          </div>
+        </section>
+
+        <section class="panel">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">Risk summaries</p>
+              <h2>Critical & high finding highlights</h2>
+              <p class="muted">Jump into the riskiest findings directly from the summary.</p>
             </div>
-            <p class="helper">Informational items for visibility.</p>
-            <div class="progress"><span id="low-progress"></span></div>
-          </article>
-        </div>
-        <div class="meta-row-bar">
-          <span id="total-count" class="pill">0 findings</span>
-          <span id="last-updated" class="pill">Waiting for data…</span>
-        </div>
+          </div>
+          <div class="callout-grid">
+            <article class="callout-card" aria-live="polite">
+              <div class="callout-header">
+                <div>
+                  <p class="label">Critical findings</p>
+                  <p class="helper">Tap an item to open its evidence.</p>
+                </div>
+                <span class="severity-pill severity-critical" id="critical-summary-count">0</span>
+              </div>
+              <div id="critical-summary-list" class="callout-list">No critical findings yet.</div>
+            </article>
+            <article class="callout-card" aria-live="polite">
+              <div class="callout-header">
+                <div>
+                  <p class="label">High findings</p>
+                  <p class="helper">Keep an eye on elevated-risk gaps.</p>
+                </div>
+                <span class="severity-pill severity-high" id="high-summary-count">0</span>
+              </div>
+              <div id="high-summary-list" class="callout-list">No high findings yet.</div>
+            </article>
+          </div>
+        </section>
       </section>
 
-      <section class="panel">
-        <div class="section-heading">
-          <div>
-            <p class="eyebrow">Category coverage</p>
-            <h2>Delegation, password policies, DNS, and more</h2>
-            <p class="muted">Review health by control family with quick access to detailed evidence.</p>
+      <section class="tab-panel" data-tab-panel="categories" role="tabpanel" hidden>
+        <section class="panel">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">Category coverage</p>
+              <h2>Delegation, password policies, DNS, and more</h2>
+              <p class="muted">Review health by control family with quick access to detailed evidence.</p>
+            </div>
           </div>
-        </div>
-        <div id="category-grid" class="category-grid">Load an audit JSON file to see category health.</div>
+          <div id="category-grid" class="category-grid">Load an audit JSON file to see category health.</div>
+        </section>
       </section>
 
-      <section class="panel">
-        <div class="section-heading">
-          <div>
-            <p class="eyebrow">All findings</p>
-            <h2>Tap into remediation details and references</h2>
-            <p class="muted">Each finding includes impacted objects, severity, impact, remediation steps, and linked documentation.</p>
+      <section class="tab-panel" data-tab-panel="findings" role="tabpanel" hidden>
+        <section class="panel">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">All findings</p>
+              <h2>Tap into remediation details and references</h2>
+              <p class="muted">Each finding includes impacted objects, severity, impact, remediation steps, and linked documentation.</p>
+            </div>
           </div>
-        </div>
-        <div id="findings-list" class="finding-list">No findings to display yet.</div>
+          <div id="findings-list" class="finding-list">No findings to display yet.</div>
+        </section>
       </section>
     </main>
 


### PR DESCRIPTION
## Summary
- add tabbed navigation to separate the summary, categories, and findings views
- surface identity admin counts plus critical/high callout lists in the summary tab
- keep category grid and finding cards available in dedicated panels with reactive detail modals

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692534e99ad48331a8e54a4e45fbd65c)